### PR TITLE
nvim: load fugitive on VeryLazy

### DIFF
--- a/nvim/lua/plugins/fugitive.lua
+++ b/nvim/lua/plugins/fugitive.lua
@@ -1,5 +1,5 @@
 return {
   "tpope/vim-fugitive",
   cond = vim.g.vscode ~= 1,
-  cmd = "Git",
+  event = "VeryLazy",
 }


### PR DESCRIPTION
## Summary
- change vim-fugitive to load on VeryLazy
- stop loading it only on :Git command

## Testing
- not run (config change only)