### PR TITLE
git: delta を pager と interactive diff に使う

### DIFF
--- a/git/README.md
+++ b/git/README.md
@@ -19,5 +19,4 @@
 
 必要に応じて次のソフトウェアをインストール
 
-*   [bat](https://github.com/sharkdp/bat)
 *   [delta](https://github.com/dandavison/delta)

--- a/git/gitconfig_env.txt
+++ b/git/gitconfig_env.txt
@@ -11,12 +11,11 @@
 	helper = !/usr/bin/gh auth git-credential
 [credential "https://gist.github.com"]
 	helper = !/usr/bin/gh auth git-credential
-# With bat
-[core]
-    pager = "bat --style=numbers,grid"
 # With delta
-[pager]
-    diff = delta
+[core]
+    pager = delta
+[interactive]
+    diffFilter = delta --color-only
 [delta]
     navigate = true
     line-numbers = true


### PR DESCRIPTION
## 概要
git の diff 確認で使っていた delta を、より広い差分表示フローで使えるようにしました。

## 変更内容
- git の pager を delta に変更
- interactive add 系でも delta が効くように diffFilter を追加
- bat 前提の説明を README から削除

## 補足
- merge conflict の表示形式は変更していません

Closes #32