### PR TITLE
nvim: 制御文字を表示

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -11,6 +11,8 @@ if not vim.g.vscode then
   vim.o.relativenumber = true
   vim.o.splitbelow = true
   vim.o.splitright = true
+  vim.opt.listchars = { tab = ">.", trail = "·", nbsp = "~", eol = "󰌑" }
+  vim.opt.list = true
   vim.g.fileencodings = { 'utf-8', 'sjis', 'utf-16le', 'default', 'ucs-bom', 'latin1' }
 end
 


### PR DESCRIPTION
## 概要
- listchars を設定し、タブ・行末・末尾スペースなどの制御文字を表示するようにした
- list 表示をデフォルトで有効化した

## 背景
- Neovim 上で制御文字が見えず、空白や行末の状態を把握しづらかったため

Closes #34