### PR TITLE
nvim: minuet-ai.nvim を導入

### DIFF
--- a/nvim/lua/envcfg.txt
+++ b/nvim/lua/envcfg.txt
@@ -31,4 +31,13 @@ M.enabled_languages = {
 M.pdf_viewer = "skim"
 M.pdf_viewer_options = nil
 
+-- LLM settings
+M.llm = {
+  enabled = false,
+  end_point = "https://opencode.ai/zen/go/v1/chat/completions",
+  provider_name = "OpenCode",
+  api_key_env = "OPENCODE_API_KEY",
+  model = "deepseek-v4-flash",
+}
+
 return M

--- a/nvim/lua/plugins/cmp.lua
+++ b/nvim/lua/plugins/cmp.lua
@@ -1,3 +1,5 @@
+local env = require("envcfg")
+
 return {
   "hrsh7th/nvim-cmp",
   cond = vim.g.vscode ~= 1,
@@ -26,10 +28,50 @@ return {
     },
     "dcampos/cmp-snippy",
     "onsails/lspkind.nvim",
+    env.llm.enabled and "milanglacier/minuet-ai.nvim" or nil,
   },
   config = function()
     local cmp = require("cmp")
     local lspkind = require("lspkind")
+
+    local sources = {
+      { name = "nvim_lsp" },
+      { name = "nvim_lsp_signature_help" },
+      { name = "nvim_lsp_document_symbol" },
+      { name = "crates" },
+      { name = "snippy" },
+      { name = "buffer" },
+      { name = "path" },
+      {
+        name = "spell",
+        option = {
+          keep_all_entries = false,
+          enable_in_context = function()
+            return true
+          end,
+        },
+      },
+      {
+        name = "lazydev",
+        group_index = 0,
+      },
+    }
+
+    if env.llm.enabled then
+      table.insert(sources, { name = "minuet" })
+    end
+
+    local mapping = cmp.mapping.preset.insert({
+      ["<C-b>"] = cmp.mapping.scroll_docs(-4),
+      ["<C-f>"] = cmp.mapping.scroll_docs(4),
+      ["<A-Space>"] = cmp.mapping.complete(),
+      ["<C-e>"] = cmp.mapping.abort(),
+      ["<CR>"] = cmp.mapping.confirm({ select = false }),
+    })
+
+    if env.llm.enabled then
+      mapping["<A-y>"] = require("minuet").make_cmp_map()
+    end
 
     cmp.setup({
       snippet = {
@@ -37,35 +79,11 @@ return {
           require("snippy").expand_snippet(args.body)
         end,
       },
-      mapping = cmp.mapping.preset.insert({
-        ["<C-b>"] = cmp.mapping.scroll_docs(-4),
-        ["<C-f>"] = cmp.mapping.scroll_docs(4),
-        ["<A-Space>"] = cmp.mapping.complete(),
-        ["<C-e>"] = cmp.mapping.abort(),
-        ["<CR>"] = cmp.mapping.confirm({ select = false }),
-      }),
-      sources = cmp.config.sources({
-        { name = "nvim_lsp" },
-        { name = "nvim_lsp_signature_help" },
-        { name = "nvim_lsp_document_symbol" },
-        { name = "crates" },
-        { name = "snippy" },
-        { name = "buffer" },
-        { name = "path" },
-        {
-          name = "spell",
-          option = {
-            keep_all_entries = false,
-            enable_in_context = function()
-              return true
-            end,
-          },
-        },
-        {
-          name = "lazydev",
-          group_index = 0,
-        },
-      }),
+      mapping = mapping,
+      sources = cmp.config.sources(sources),
+      performance = {
+        fetching_timeout = env.llm.enabled and 2000 or 500,
+      },
       formatting = {
         format = lspkind.cmp_format({
           mode = "symbol",

--- a/nvim/lua/plugins/minuet.lua
+++ b/nvim/lua/plugins/minuet.lua
@@ -1,0 +1,29 @@
+local env = require("envcfg")
+local llm = env.llm
+
+return {
+  "milanglacier/minuet-ai.nvim",
+  enabled = not vim.g.vscode and llm.enabled,
+  dependencies = { "nvim-lua/plenary.nvim" },
+  config = function()
+    require("minuet").setup({
+      provider = "openai_compatible",
+      request_timeout = 2.5,
+      throttle = 2000,
+      debounce = 800,
+      provider_options = {
+        openai_compatible = {
+          api_key = llm.api_key_env,
+          end_point = llm.end_point,
+          model = llm.model,
+          name = llm.provider_name,
+          optional = {
+            max_tokens = 56,
+            top_p = 0.9,
+            thinking = { type = "disabled" },
+          },
+        },
+      },
+    })
+  end,
+}

--- a/zsh/zsh_envcfg.txt
+++ b/zsh/zsh_envcfg.txt
@@ -105,3 +105,6 @@ RPROMPT='%F{66}%3~%f %F{244}%m%f'
 ## For SUSE
 # PROMPT='%F{46}%n%f %c $GITSTATUS_PROMPT%F{46}%B %# %b%f'
 # RPROMPT='%F{107}%3~%f %F{244}%m%f' 
+
+# Setting for OpenCode
+export OPENCODE_API_KEY=""


### PR DESCRIPTION
## 変更内容
- `minuet-ai.nvim` を導入し、nvim-cmp と連携
- LLM 設定を `envcfg.txt` に追加（OpenCode API 対応）
- `zsh` に `OPENCODE_API_KEY` の環境変数設定を追加
- LLM 補完は `env.llm.enabled` で条件付き有効化可能

## 背景
issue #36 の通り、minuet-ai.nvim を試して導入する。

Closes #36