### PR TITLE
nvim: markdown プレビュー拡張機能の導入と環境対応

### DIFF
--- a/nvim/lua/envcfg.txt
+++ b/nvim/lua/envcfg.txt
@@ -40,4 +40,26 @@ M.llm = {
   model = "deepseek-v4-flash",
 }
 
+-- Markdown preview plugin selection
+M.md_preview = {
+  options = {
+    MD_PREVIEW = "md-preview",
+    PREVIEW = "preview",
+  },
+  prefer = "preview",
+}
+
+-- Returns the plugin to use based on environment
+-- md-preview requires unix + glow, otherwise falls back to preview
+function M.get_md_preview_plugin()
+  if M.md_preview.prefer == M.md_preview.options.MD_PREVIEW then
+    if vim.fn.has("unix") == 1 and vim.fn.executable("glow") == 1 then
+      return M.md_preview.options.MD_PREVIEW
+    else
+      return M.md_preview.options.PREVIEW
+    end
+  end
+  return M.md_preview.prefer
+end
+
 return M

--- a/nvim/lua/plugins/markdown-preview.lua
+++ b/nvim/lua/plugins/markdown-preview.lua
@@ -1,8 +1,13 @@
 return {
   "iamcco/markdown-preview.nvim",
-  cond = vim.g.vscode ~= 1,
-  build = function()
-    vim.fn["mkdp#util#install"]()
+  enabled = function()
+    local sysname = vim.loop.os_uname().sysname
+    if sysname == "Linux" then
+      return not not (vim.env.DISPLAY or vim.env.WAYLAND_DISPLAY)
+    end
+    return true
   end,
-  ft = "markdown",
+  cond = vim.g.vscode ~= 1,
+  build = "cd app && npm install",
+  ft = { "markdown" },
 }

--- a/nvim/lua/plugins/md-preview.lua
+++ b/nvim/lua/plugins/md-preview.lua
@@ -1,6 +1,8 @@
+local envcfg = require("envcfg")
 return {
   "topazape/md-preview.nvim",
-  enabled = vim.fn.has("unix") == 1,
+  cond = vim.g.vscode ~= 1,
+  enabled = envcfg.get_md_preview_plugin() == envcfg.md_preview.options.MD_PREVIEW,
   ft = { "md", "markdown", "mkd", "mkdn", "mdwn", "mdown", "mdtxt", "mdtext", "rmd", "wiki" },
   opts = {
     viewer = {

--- a/nvim/lua/plugins/preview.lua
+++ b/nvim/lua/plugins/preview.lua
@@ -1,0 +1,8 @@
+return {
+  "henriklovhaug/Preview.nvim",
+  cond = vim.g.vscode ~= 1,
+  ft = "markdown",
+  config = function()
+    require("preview").setup()
+  end,
+}

--- a/nvim/lua/plugins/preview.lua
+++ b/nvim/lua/plugins/preview.lua
@@ -1,6 +1,8 @@
+local envcfg = require("envcfg")
 return {
   "henriklovhaug/Preview.nvim",
   cond = vim.g.vscode ~= 1,
+  enabled = envcfg.get_md_preview_plugin() == envcfg.md_preview.options.PREVIEW,
   ft = "markdown",
   config = function()
     require("preview").setup()


### PR DESCRIPTION
## 変更内容
- Preview.nvimプラグインを追加（md-tuiベース）
- 環境に応じたmarkdownプレビュー拡張機能の切り替え設定を追加
- markdown-previewをnpmビルドに切り替え、ディスプレイチェック機能を追加

## 理由
markdownプレビューを確認する拡張機能の使い分けが行われていなかったため、環境に応じた適切なプレビュー機能を提供するため。

Closes #39