### PR TITLE
nvim: minuet-ai.nvim から plenary.nvim の依存関係を削除

### DIFF
--- a/nvim/lua/plugins/minuet.lua
+++ b/nvim/lua/plugins/minuet.lua
@@ -4,7 +4,6 @@ local llm = env.llm
 return {
   "milanglacier/minuet-ai.nvim",
   enabled = not vim.g.vscode and llm.enabled,
-  dependencies = { "nvim-lua/plenary.nvim" },
   config = function()
     require("minuet").setup({
       provider = "openai_compatible",


### PR DESCRIPTION
minuet-ai.nvim の設定ファイルから plenary.nvim への依存関係を削除しました。

minuet-ai.nvim は plenary.nvim に依存していないため、不要な依存関係を削除します。

Closes #41