### PR TITLE
nvim: 古い branch 指定を version 指定に変更

### DIFF
--- a/nvim/lua/plugins/telescope.lua
+++ b/nvim/lua/plugins/telescope.lua
@@ -1,7 +1,7 @@
 return {
   "nvim-telescope/telescope.nvim",
   cond = vim.g.vscode ~= 1,
-  branch = "0.1.x",
+  version = "*",
   opts = {},
   cmd = "Telescope",
   keys = {


### PR DESCRIPTION
## 変更内容
Telescope のインストール指定を `branch = "0.1.x"` から `version = "*"` に変更しました。

## 背景
古いブランチ指定により treesitter 周りでエラーが発生していました。Telescope の README では `version = "*"` によるインストールが推奨されており、これに追従します。

Closes #46